### PR TITLE
fix: adjust label sync permissions

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
-  metadata: read
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary

-

## Testing

- [ ] `npm run lint`
- [ ] `npm run type-check`
- [ ] `npm run build`
- [ ] `npx playwright test`

## Additional Notes

-
