### PR TITLE
ci: wait for checks before dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -36,6 +36,12 @@ jobs:
               event: 'APPROVE'
             })
 
+      - name: Wait for status checks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr checks "${{ github.event.pull_request.number }}" --watch --fail-fast --repo "${{ github.repository }}"
+
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a status check gate before enabling Dependabot auto-merge
- block the gh merge command when any required check fails

## Testing
- git hooks: format:check, lint, type-check, build
